### PR TITLE
Fix: use upstream cairo-vm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", rev = "feb7b248ccfb082b2e898b387f8f474fa3e170d0", features = ["extensive_hints"] }
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", rev = "05352b1c67859a4d8cd128575c1e68ca7e300341", features = ["extensive_hints"] }
 num-traits = "0.2.19"
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"

--- a/examples/run_program.rs
+++ b/examples/run_program.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use cairo_vm::cairo_run::{cairo_run_program, CairoRunConfig};
+use cairo_vm::cairo_run::{cairo_run_program_with_initial_scope, CairoRunConfig};
 use cairo_vm::types::exec_scope::ExecutionScopes;
 use cairo_vm::types::layout_name::LayoutName;
 use cairo_vm::types::program::Program;
@@ -53,11 +53,11 @@ fn cairo_run_bootloader_in_proof_mode(
     insert_bootloader_input(&mut exec_scopes, bootloader_input);
 
     // Run the bootloader
-    cairo_run_program(
+    cairo_run_program_with_initial_scope(
         &bootloader_program,
         &cairo_run_config,
         &mut hint_processor,
-        Some(exec_scopes),
+        exec_scopes,
     )
 }
 


### PR DESCRIPTION
All the PRs required have been merged in cairo-vm, we can now use the latest version.

## Type

- [ ] feature
- [ ] bugfix
- [x] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [ ] yes
- [x] no
