### PR TITLE
Feature: PIE example + run bootloader helper

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,6 +39,10 @@ jobs:
       - name: Run Rust tests
         run: |
           RUSTFLAGS="-D warnings" cargo test
+      - name: Run examples
+        run: |
+          RUSTFLAGS="-D warnings" cargo run --example run_cairo_pie
+          RUSTFLAGS="-D warnings" cargo run --example run_program
 
   udeps:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", rev = "05352b1c67859a4d8cd128575c1e68ca7e300341", features = ["extensive_hints"] }
+cairo-vm = { git = "https://github.com/lambdaclass/cairo-vm", rev = "fdf3fee0eab32db0e55aeaba63ee581a55c16c58", features = ["extensive_hints"] }
 num-traits = "0.2.19"
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"

--- a/examples/run_cairo_pie.rs
+++ b/examples/run_cairo_pie.rs
@@ -1,18 +1,16 @@
 use std::error::Error;
 
-use cairo_bootloader::bootloaders::load_bootloader;
 use cairo_bootloader::cairo_run_bootloader_in_proof_mode;
 use cairo_bootloader::tasks::make_bootloader_tasks;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let bootloader_program = load_bootloader()?;
     let fibonacci_pie = include_bytes!(
         "../dependencies/test-programs/bootloader/pies/fibonacci-stone-e2e/cairo_pie.zip"
     );
 
     let tasks = make_bootloader_tasks(&[], &[fibonacci_pie])?;
 
-    let mut runner = cairo_run_bootloader_in_proof_mode(&bootloader_program, tasks)?;
+    let mut runner = cairo_run_bootloader_in_proof_mode(tasks)?;
 
     let mut output_buffer = "Bootloader output:\n".to_string();
     runner.vm.write_output(&mut output_buffer)?;

--- a/examples/run_cairo_pie.rs
+++ b/examples/run_cairo_pie.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let tasks = make_bootloader_tasks(&[], &[fibonacci_pie])?;
 
-    let mut runner = cairo_run_bootloader_in_proof_mode(tasks)?;
+    let mut runner = cairo_run_bootloader_in_proof_mode(tasks, None, None, None)?;
 
     let mut output_buffer = "Bootloader output:\n".to_string();
     runner.vm.write_output(&mut output_buffer)?;

--- a/examples/run_cairo_pie.rs
+++ b/examples/run_cairo_pie.rs
@@ -6,9 +6,11 @@ use cairo_bootloader::tasks::make_bootloader_tasks;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let bootloader_program = load_bootloader()?;
-    let fibonacci_program = include_bytes!("fibonacci.json");
+    let fibonacci_pie = include_bytes!(
+        "../dependencies/test-programs/bootloader/pies/fibonacci-stone-e2e/cairo_pie.zip"
+    );
 
-    let tasks = make_bootloader_tasks(&[fibonacci_program], &[])?;
+    let tasks = make_bootloader_tasks(&[], &[fibonacci_pie])?;
 
     let mut runner = cairo_run_bootloader_in_proof_mode(&bootloader_program, tasks)?;
 

--- a/examples/run_program.rs
+++ b/examples/run_program.rs
@@ -1,16 +1,14 @@
 use std::error::Error;
 
-use cairo_bootloader::bootloaders::load_bootloader;
 use cairo_bootloader::cairo_run_bootloader_in_proof_mode;
 use cairo_bootloader::tasks::make_bootloader_tasks;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let bootloader_program = load_bootloader()?;
     let fibonacci_program = include_bytes!("fibonacci.json");
 
     let tasks = make_bootloader_tasks(&[fibonacci_program], &[])?;
 
-    let mut runner = cairo_run_bootloader_in_proof_mode(&bootloader_program, tasks)?;
+    let mut runner = cairo_run_bootloader_in_proof_mode(tasks)?;
 
     let mut output_buffer = "Bootloader output:\n".to_string();
     runner.vm.write_output(&mut output_buffer)?;

--- a/examples/run_program.rs
+++ b/examples/run_program.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let tasks = make_bootloader_tasks(&[fibonacci_program], &[])?;
 
-    let mut runner = cairo_run_bootloader_in_proof_mode(tasks)?;
+    let mut runner = cairo_run_bootloader_in_proof_mode(tasks, None, None, None)?;
 
     let mut output_buffer = "Bootloader output:\n".to_string();
     runner.vm.write_output(&mut output_buffer)?;

--- a/src/hints/mod.rs
+++ b/src/hints/mod.rs
@@ -9,7 +9,7 @@ mod program_hash;
 mod program_loader;
 mod select_builtins;
 mod simple_bootloader_hints;
-mod types;
+pub(crate) mod types;
 mod vars;
 
 pub use hint_processors::{BootloaderHintProcessor, MinimalBootloaderHintProcessor};
@@ -17,4 +17,4 @@ pub use types::{
     BootloaderConfig, BootloaderInput, PackedOutput, SimpleBootloaderInput, Task, TaskSpec,
 };
 
-pub use vars::BOOTLOADER_INPUT;
+pub use vars::{BOOTLOADER_INPUT, BOOTLOADER_PROGRAM_IDENTIFIERS};

--- a/src/hints/types.rs
+++ b/src/hints/types.rs
@@ -80,11 +80,11 @@ pub struct BootloaderInput {
 }
 
 impl BootloaderInput {
-    pub fn from_tasks(tasks: Vec<TaskSpec>) -> Self {
+    pub fn new(tasks: Vec<TaskSpec>, fact_topologies_path: Option<PathBuf>) -> Self {
         let n_tasks = tasks.len();
         Self {
             simple_bootloader_input: SimpleBootloaderInput {
-                fact_topologies_path: None,
+                fact_topologies_path,
                 single_page: false,
                 tasks,
             },

--- a/src/hints/types.rs
+++ b/src/hints/types.rs
@@ -78,3 +78,21 @@ pub struct BootloaderInput {
     pub bootloader_config: BootloaderConfig,
     pub packed_outputs: Vec<PackedOutput>,
 }
+
+impl BootloaderInput {
+    pub fn from_tasks(tasks: Vec<TaskSpec>) -> Self {
+        let n_tasks = tasks.len();
+        Self {
+            simple_bootloader_input: SimpleBootloaderInput {
+                fact_topologies_path: None,
+                single_page: false,
+                tasks,
+            },
+            bootloader_config: BootloaderConfig {
+                simple_bootloader_program_hash: Felt252::from(0),
+                supported_cairo_verifier_program_hashes: vec![],
+            },
+            packed_outputs: vec![PackedOutput::Plain(vec![]); n_tasks],
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
+use crate::hints::types::ProgramIdentifiers;
+use cairo_vm::cairo_run::{cairo_run_program_with_initial_scope, CairoRunConfig};
 use cairo_vm::types::exec_scope::ExecutionScopes;
+use cairo_vm::types::layout_name::LayoutName;
+use cairo_vm::types::program::Program;
+use cairo_vm::vm::errors::cairo_run_errors::CairoRunError;
+use cairo_vm::vm::runners::cairo_runner::CairoRunner;
 pub use hints::*;
 
 pub mod bootloaders;
@@ -8,10 +14,53 @@ pub mod tasks;
 #[cfg(test)]
 pub mod macros;
 
-/// Inserts the bootloader input in the execution scopes.
-pub fn insert_bootloader_input(
+/// Inserts the bootloader input and program identifiers in the execution scopes.
+pub fn prepare_bootloader_exec_scopes(
     exec_scopes: &mut ExecutionScopes,
     bootloader_input: BootloaderInput,
+    bootloader_program: &Program,
 ) {
     exec_scopes.insert_value(BOOTLOADER_INPUT, bootloader_input);
+    let identifiers: ProgramIdentifiers = bootloader_program
+        .iter_identifiers()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect();
+    exec_scopes.insert_value(BOOTLOADER_PROGRAM_IDENTIFIERS, identifiers);
+}
+
+/// A helper function to run the bootloader in proof mode.
+///
+/// Reimplement your own version of this function if you wish to modify the Cairo run config
+/// or other parameters.
+pub fn cairo_run_bootloader_in_proof_mode(
+    bootloader_program: &Program,
+    tasks: Vec<TaskSpec>,
+) -> Result<CairoRunner, CairoRunError> {
+    let mut hint_processor = BootloaderHintProcessor::new();
+
+    let cairo_run_config = CairoRunConfig {
+        entrypoint: "main",
+        trace_enabled: false,
+        relocate_mem: false,
+        layout: LayoutName::starknet_with_keccak,
+        proof_mode: true,
+        secure_run: None,
+        disable_trace_padding: false,
+        allow_missing_builtins: None,
+    };
+
+    // Build the bootloader input
+    let bootloader_input = BootloaderInput::from_tasks(tasks);
+
+    // Load initial variables in the exec scopes
+    let mut exec_scopes = ExecutionScopes::new();
+    prepare_bootloader_exec_scopes(&mut exec_scopes, bootloader_input, bootloader_program);
+
+    // Run the bootloader
+    cairo_run_program_with_initial_scope(
+        bootloader_program,
+        &cairo_run_config,
+        &mut hint_processor,
+        exec_scopes,
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::bootloaders::load_bootloader;
 use crate::hints::types::ProgramIdentifiers;
 use cairo_vm::cairo_run::{cairo_run_program_with_initial_scope, CairoRunConfig};
 use cairo_vm::types::exec_scope::ExecutionScopes;
@@ -33,10 +34,11 @@ pub fn prepare_bootloader_exec_scopes(
 /// Reimplement your own version of this function if you wish to modify the Cairo run config
 /// or other parameters.
 pub fn cairo_run_bootloader_in_proof_mode(
-    bootloader_program: &Program,
     tasks: Vec<TaskSpec>,
 ) -> Result<CairoRunner, CairoRunError> {
     let mut hint_processor = BootloaderHintProcessor::new();
+
+    let bootloader_program = load_bootloader()?;
 
     let cairo_run_config = CairoRunConfig {
         entrypoint: "main",
@@ -54,11 +56,11 @@ pub fn cairo_run_bootloader_in_proof_mode(
 
     // Load initial variables in the exec scopes
     let mut exec_scopes = ExecutionScopes::new();
-    prepare_bootloader_exec_scopes(&mut exec_scopes, bootloader_input, bootloader_program);
+    prepare_bootloader_exec_scopes(&mut exec_scopes, bootloader_input, &bootloader_program);
 
     // Run the bootloader
     cairo_run_program_with_initial_scope(
-        bootloader_program,
+        &bootloader_program,
         &cairo_run_config,
         &mut hint_processor,
         exec_scopes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,8 @@ pub fn cairo_run_bootloader_in_proof_mode(
 
     let cairo_run_config = CairoRunConfig {
         entrypoint: "main",
-        trace_enabled: false,
-        relocate_mem: false,
+        trace_enabled: true,
+        relocate_mem: true,
         layout: layout.unwrap_or(LayoutName::starknet_with_keccak),
         proof_mode: true,
         secure_run: None,


### PR DESCRIPTION
Problems:
1. We do not have a working example for Cairo PIEs
2. It would be convenient for developers to have a helper function to run the bootloader in proof mode easily.

Solutions:
1. Add an example for how to run a Cairo PIE
2. Move the `cairo_run_bootloader_in_proof_mode` from the Stone prover SDK to this repository. This helper is now implemented in a way that makes it easy to reimplement your own version if needed.

## Type

- [x] feature
- [ ] bugfix
- [ ] dev (no functional changes, no API changes)
- [ ] fmt (formatting, renaming)
- [ ] build
- [ ] docs
- [ ] testing

## Description


## Breaking changes?

- [x] yes, renamed a public helper function.
- [ ] no
