### PR TITLE
Feature: load_hints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ thiserror-no-std = "2.0.2"
 assert_matches = "1.5.0"
 rstest = "0.19.0"
 
+[patch."https://github.com/lambdaclass/cairo-vm"]
+cairo-vm = { path = "../cairo-vm/vm" }


### PR DESCRIPTION
Problem: A program's hints need to be properly loaded using `cairo-vm`'s `extensive-hint` feature and need to have their `pc` properly relocated.

Solution: Implement this logic during the `load_program_hint` using `cairo-lang`'s `def load_hints()` as inspiration.

Note that this currently requires some trivial mods to `cairo-vm` (which I've done locally using a cargo patch) in order to make some items public.